### PR TITLE
Add ECIES encryption and decryption support.

### DIFF
--- a/SecureEnclaveSwift/SecureEnclaveDemo/Manager.swift
+++ b/SecureEnclaveSwift/SecureEnclaveDemo/Manager.swift
@@ -44,6 +44,18 @@ final class Manager {
         return signed
     }
     
+    func encrypt(_ data: Data) throws -> Data {
+        let keys = try getKeys()
+        let signed = try helper.encrypt(data, publicKey: keys.public.ref)
+        return signed
+    }
+    
+    func decrypt(_ data: Data) throws -> Data {
+        let keys = try getKeys()
+        let signed = try helper.decrypt(data, privateKey: keys.private)
+        return signed
+    }
+    
     private func getKeys() throws -> (`public`: SecureEnclaveKeyData, `private`: SecureEnclaveKeyReference) {
         if let publicKeyRef = try? helper.getPublicKey(), let privateKey = try? helper.getPrivateKey() {
             return (public: publicKeyRef, private: privateKey)

--- a/SecureEnclaveSwift/SecureEnclaveDemo/Manager.swift
+++ b/SecureEnclaveSwift/SecureEnclaveDemo/Manager.swift
@@ -44,12 +44,14 @@ final class Manager {
         return signed
     }
     
+    @available(iOS 10.3, *)
     func encrypt(_ data: Data) throws -> Data {
         let keys = try getKeys()
         let signed = try helper.encrypt(data, publicKey: keys.public.ref)
         return signed
     }
     
+    @available(iOS 10.3, *)
     func decrypt(_ data: Data) throws -> Data {
         let keys = try getKeys()
         let signed = try helper.decrypt(data, privateKey: keys.private)

--- a/SecureEnclaveSwift/SecureEnclaveHelper.swift
+++ b/SecureEnclaveSwift/SecureEnclaveHelper.swift
@@ -189,6 +189,30 @@ final class SecureEnclaveHelper {
         return true
     }
     
+    func encrypt(_ digest: Data, publicKey: SecureEnclaveKeyReference) throws -> Data {
+        var error : Unmanaged<CFError>?
+
+        let result = SecKeyCreateEncryptedData(publicKey.underlying, SecKeyAlgorithm.eciesEncryptionStandardX963SHA256AESGCM, digest as CFData, &error)
+        
+        if result == nil {
+            throw SecureEnclaveHelperError(message: "\(error)", osStatus: 0)
+        }
+
+        return result as! Data
+    }
+    
+    func decrypt(_ digest: Data, privateKey: SecureEnclaveKeyReference) throws -> Data {
+        var error : Unmanaged<CFError>?
+        
+        let result = SecKeyCreateDecryptedData(privateKey.underlying, SecKeyAlgorithm.eciesEncryptionStandardX963SHA256AESGCM, digest as CFData, &error)
+        
+        if result == nil {
+            throw SecureEnclaveHelperError(message: "\(error)", osStatus: 0)
+        }
+        
+        return result as! Data
+    }
+    
     func forceSavePublicKey(_ publicKey: SecureEnclaveKeyReference) throws {
         
         let query: [String: Any] = [

--- a/SecureEnclaveSwift/SecureEnclaveHelper.swift
+++ b/SecureEnclaveSwift/SecureEnclaveHelper.swift
@@ -189,6 +189,7 @@ final class SecureEnclaveHelper {
         return true
     }
     
+    @available(iOS 10.3, *)
     func encrypt(_ digest: Data, publicKey: SecureEnclaveKeyReference) throws -> Data {
         var error : Unmanaged<CFError>?
 
@@ -201,6 +202,7 @@ final class SecureEnclaveHelper {
         return result as! Data
     }
     
+    @available(iOS 10.3, *)
     func decrypt(_ digest: Data, privateKey: SecureEnclaveKeyReference) throws -> Data {
         var error : Unmanaged<CFError>?
         


### PR DESCRIPTION
The decryption API only works on iOS 10.3 and above. I was told it being broken was a bug (rdar://problem/29438764), and it appears to work in the latest beta.

Usage is pretty straightforward:
```swift
let encrypted = try Manager.shared.encrypt("Hello!".data(using: .utf8)!)
let decrypted = try Manager.shared.decrypt(encrypted) // "Hello!"
```

Uses SHA256 for the KDF which should be a sane default.